### PR TITLE
Fixed regression causing image mosaics to not support time

### DIFF
--- a/app/modules/query/opLayerService.js
+++ b/app/modules/query/opLayerService.js
@@ -201,16 +201,13 @@ angular.module('opApp').service('opLayerService', ['$q', 'localStorageService', 
                         deferred.resolve(layer.fields);
                     },
                     function (reason) {
-                        // Disabling the forced override that happens for geometry and time fields.
                         // This is to allow time-enabled raster mosaics to function.
-                        //layer.fields = { time: null, geometry: null };
                         self.setFieldCache(layer, layer.fields);
                         layer.raster = true;
 
                         $log.log('Unable to determine field types: ' + reason);
-                        deferred.resolve(reason);
+                        deferred.resolve(layer.fields);
                         $log.log('Assuming raster layer.');
-                        // deferred.resolve(layer.fields);
                     });
 
                 return deferred.promise;


### PR DESCRIPTION
DescribeFeatureTypes failing for WFS is what is used to identify a layer as raster backed. When the reason is deferred.resolved on it is placed into the layer.fields object causing the structure to be broken.  Replacing the deferred.resolve(reason) with deferred.resolve(layer.fields) corrects this oversight.
